### PR TITLE
Update About section content and imagery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -289,17 +289,19 @@ export default function AIAutomationLanding() {
         <div className="mx-auto max-w-5xl px-4 py-16 grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-center">
           <div>
             <p className="text-sm uppercase tracking-[0.3em] text-[#08898E]">About me</p>
-            <h2 className="mt-3 text-3xl font-bold">Hi, I’m Augustyn Mat</h2>
+            <h2 className="mt-3 text-3xl font-bold">Hi, I’m Mat</h2>
             <p className="mt-4 text-slate-600 text-lg leading-relaxed">
-              I’m an automation consultant who mixes no-code tools with AI to remove manual work from
-              growing companies. Over the past 7 years I’ve prototyped chatbots, lead qualification flows,
-              and back-office automations that let teams focus on customers instead of admin.
+              With over 13 years in IT, I’ve grown from Service Desk roles through Infrastructure to managing
+              Azure Cloud environments. Along the way, I earned Six Sigma and Lean accreditations, giving me a
+              strong foundation in process optimization and efficiency. When AI emerged as a transformative
+              tool, I quickly expanded my skills with professional automation training to combine proven
+              methodologies with cutting-edge technology.
             </p>
             <p className="mt-4 text-slate-600">
-              My background spans customer support, operations, and product enablement. That blend helps me
-              translate “this takes too long” into automations that are transparent, documented, and easy to
-              hand over. When we work together you’ll always know what the agent does, how it’s monitored, and
-              how to iterate on it.
+              At AI-IT, my mission is simple: make automation accessible, reliable, and tailored to your
+              business. No half-baked solutions or flashy promises—just practical, results-driven systems that
+              streamline recruitment, enhance client communication, and automate back-office tasks. The goal is
+              to free your time and let you focus on growth.
             </p>
             <div className="mt-6 flex flex-wrap gap-3 text-sm text-slate-500">
               <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
@@ -314,8 +316,8 @@ export default function AIAutomationLanding() {
             <div className="absolute inset-0 translate-x-4 translate-y-4 rounded-3xl bg-[#6AACA4]/20 blur-2xl" aria-hidden="true"></div>
             <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-xl">
               <img
-                src="/assets/about-portrait.svg"
-                alt="Augustyn Mat smiling in front of a teal background"
+                src="/assets/nanobanana-[nanobanana.io]-1758893121257.png"
+                alt="Mat smiling"
                 className="w-full h-full object-cover"
               />
             </div>


### PR DESCRIPTION
## Summary
- replace the About Me heading and narrative with updated career overview and mission statement
- swap the About section illustration for the provided portrait asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da424f81d483329c82421d0dfabf68